### PR TITLE
Updating conditional to build-and-push Github workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,7 +15,7 @@ jobs:
       - name: "Checkout source code at current commit"
         uses: actions/checkout@v2
       - name: Prepare tags for Docker image
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: (github.event_name != 'pull_request' && github.ref == 'master') || github.event.pull_request.head.repo.full_name == github.repository
         id: prepare
         run: |
           TAGS=${{ github.repository }}:sha-${GITHUB_SHA:0:7}
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: (github.event_name != 'pull_request' && github.ref == 'master') || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -43,5 +43,5 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v2
         with:
-          push: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+          push: ${{ (github.event_name != 'pull_request' && github.ref == 'master') || github.event.pull_request.head.repo.full_name == github.repository }}
           tags: ${{ steps.prepare.outputs.tags }}


### PR DESCRIPTION
## what & why?

We need to build/publish master when triggered. The added logic triggers the steps if the branch is `master` but not if it's a pull request (since the source branch in a forked repo could also be `master`).
