### PR TITLE
Fixing Docker Hub publishes

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -1,4 +1,4 @@
-name-template: 'v$RESOLVED_VERSION'
+name-template: '$RESOLVED_VERSION'
 tag-template: '$RESOLVED_VERSION'
 version-template: '$MAJOR.$MINOR.$PATCH'
 version-resolver:

--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -1,4 +1,4 @@
-name-template: '$RESOLVED_VERSION'
+name-template: 'v$RESOLVED_VERSION'
 tag-template: '$RESOLVED_VERSION'
 version-template: '$MAJOR.$MINOR.$PATCH'
 version-resolver:

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - fix-release-build
 
 jobs:
   semver:

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - fix-release-build
 
 jobs:
   semver:
@@ -16,4 +17,4 @@ jobs:
            prerelease: false
            config-name: auto-release.yml
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ jobs:
       - name: "Checkout source code at current commit"
         uses: actions/checkout@v2
       - name: Prepare tags for Docker image
-        if: github.event.release.action == 'released' || github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event.release.action == 'created'
         id: prepare
         run: |
           TAGS=${{ github.repository }}:sha-${GITHUB_SHA:0:7}
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
-        if: github.event.release.action == 'released' || github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event.release.action == 'created' || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -40,5 +40,5 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v2
         with:
-          push: ${{ github.event.release.action == 'released' || github.event.pull_request.head.repo.full_name == github.repository }}
+          push: ${{ github.event.release.action == 'created' || github.event.pull_request.head.repo.full_name == github.repository }}
           tags: ${{ steps.prepare.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,7 +15,7 @@ jobs:
       - name: "Checkout source code at current commit"
         uses: actions/checkout@v2
       - name: Prepare tags for Docker image
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: (github.event_name != 'pull_request' && github.ref == 'master') || github.event.pull_request.head.repo.full_name == github.repository
         id: prepare
         run: |
           TAGS=${{ github.repository }}:sha-${GITHUB_SHA:0:7}
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: (github.event_name != 'pull_request' && github.ref == 'master') || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -43,5 +43,5 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v2
         with:
-          push: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+          push: ${{ (github.event_name != 'pull_request' && github.ref == 'master') || github.event.pull_request.head.repo.full_name == github.repository }}
           tags: ${{ steps.prepare.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,10 +1,10 @@
 name: "docker"
 on:
-  push:
-    tags:
-      - '*.*.*'
   pull_request: 
     types: [opened, synchronize, reopened]
+  release:
+    types:
+      - created
 jobs:
   build-and-push:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ jobs:
       - name: "Checkout source code at current commit"
         uses: actions/checkout@v2
       - name: Prepare tags for Docker image
-        if: github.event.release.action == 'created'
+        if: github.event_name == 'release' && github.event.action == 'created'
         id: prepare
         run: |
           TAGS=${{ github.repository }}:sha-${GITHUB_SHA:0:7}
@@ -28,17 +28,17 @@ jobs:
             TAGS="$TAGS,${{ github.repository }}:latest"
           fi
           echo ::set-output name=tags::${TAGS}
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Login to DockerHub
-        if: github.event.release.action == 'created' || github.event.pull_request.head.repo.full_name == github.repository
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-      - name: "Build and push docker image to DockerHub"
-        id: docker_build
-        uses: docker/build-push-action@v2
-        with:
-          push: ${{ github.event.release.action == 'created' || github.event.pull_request.head.repo.full_name == github.repository }}
-          tags: ${{ steps.prepare.outputs.tags }}
+      #- name: Set up Docker Buildx
+      #  uses: docker/setup-buildx-action@v1
+      #- name: Login to DockerHub
+      #  if: github.event.release.action == 'created' || github.event.pull_request.head.repo.full_name == github.repository
+      #  uses: docker/login-action@v1
+      #  with:
+      #    username: ${{ secrets.DOCKERHUB_USERNAME }}
+      #    password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      #- name: "Build and push docker image to DockerHub"
+      #  id: docker_build
+      #  uses: docker/build-push-action@v2
+      #  with:
+      #    push: ${{ github.event.release.action == 'created' || github.event.pull_request.head.repo.full_name == github.repository }}
+      #    tags: ${{ steps.prepare.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,6 +15,8 @@ jobs:
         if: github.event_name == 'release' && github.event.action == 'created'
         id: prepare
         run: |
+          echo ${{ github.event_name }}
+          echo ${{ github.event.action }}
           TAGS=${{ github.repository }}:sha-${GITHUB_SHA:0:7}
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/}
@@ -28,17 +30,17 @@ jobs:
             TAGS="$TAGS,${{ github.repository }}:latest"
           fi
           echo ::set-output name=tags::${TAGS}
-      #- name: Set up Docker Buildx
+      # - name: Set up Docker Buildx
       #  uses: docker/setup-buildx-action@v1
-      #- name: Login to DockerHub
-      #  if: github.event.release.action == 'created' || github.event.pull_request.head.repo.full_name == github.repository
+      # - name: Login to DockerHub
+      #  if: (github.event_name == 'release' && github.event.action == 'created') || github.event.pull_request.head.repo.full_name == github.repository
       #  uses: docker/login-action@v1
       #  with:
       #    username: ${{ secrets.DOCKERHUB_USERNAME }}
       #    password: ${{ secrets.DOCKERHUB_PASSWORD }}
-      #- name: "Build and push docker image to DockerHub"
+      # - name: "Build and push docker image to DockerHub"
       #  id: docker_build
       #  uses: docker/build-push-action@v2
       #  with:
-      #    push: ${{ github.event.release.action == 'created' || github.event.pull_request.head.repo.full_name == github.repository }}
+      #    push: ${{ (github.event_name == 'release' && github.event.action == 'created') || github.event.pull_request.head.repo.full_name == github.repository }}
       #    tags: ${{ steps.prepare.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ jobs:
       - name: "Checkout source code at current commit"
         uses: actions/checkout@v2
       - name: Prepare tags for Docker image
-        if: (github.event_name != 'pull_request' && startsWith(github.ref, 'ref/tags/')) || github.event.pull_request.head.repo.full_name == github.repository
+        if: (github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/')) || github.event.pull_request.head.repo.full_name == github.repository
         id: prepare
         run: |
           TAGS=${{ github.repository }}:sha-${GITHUB_SHA:0:7}
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
-        if: (github.event_name != 'pull_request' && startsWith(github.ref, 'ref/tags/')) || github.event.pull_request.head.repo.full_name == github.repository
+        if: (github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/')) || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -40,5 +40,5 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v2
         with:
-          push: ${{ (github.event_name != 'pull_request' && startsWith(github.ref, 'ref/tags/')) || github.event.pull_request.head.repo.full_name == github.repository }}
+          push: ${{ (github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/')) || github.event.pull_request.head.repo.full_name == github.repository }}
           tags: ${{ steps.prepare.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,11 +12,9 @@ jobs:
       - name: "Checkout source code at current commit"
         uses: actions/checkout@v2
       - name: Prepare tags for Docker image
-        if: github.event_name == 'release' && github.event.action == 'created'
+        if: (github.event_name == 'release' && github.event.action == 'created') || github.event.pull_request.head.repo.full_name == github.repository
         id: prepare
         run: |
-          echo ${{ github.event_name }}
-          echo ${{ github.event.action }}
           TAGS=${{ github.repository }}:sha-${GITHUB_SHA:0:7}
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/}
@@ -30,17 +28,17 @@ jobs:
             TAGS="$TAGS,${{ github.repository }}:latest"
           fi
           echo ::set-output name=tags::${TAGS}
-      # - name: Set up Docker Buildx
-      #  uses: docker/setup-buildx-action@v1
-      # - name: Login to DockerHub
-      #  if: (github.event_name == 'release' && github.event.action == 'created') || github.event.pull_request.head.repo.full_name == github.repository
-      #  uses: docker/login-action@v1
-      #  with:
-      #    username: ${{ secrets.DOCKERHUB_USERNAME }}
-      #    password: ${{ secrets.DOCKERHUB_PASSWORD }}
-      # - name: "Build and push docker image to DockerHub"
-      #  id: docker_build
-      #  uses: docker/build-push-action@v2
-      #  with:
-      #    push: ${{ (github.event_name == 'release' && github.event.action == 'created') || github.event.pull_request.head.repo.full_name == github.repository }}
-      #    tags: ${{ steps.prepare.outputs.tags }}
+      - name: Set up Docker Buildx
+       uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+       if: (github.event_name == 'release' && github.event.action == 'created') || github.event.pull_request.head.repo.full_name == github.repository
+       uses: docker/login-action@v1
+       with:
+         username: ${{ secrets.DOCKERHUB_USERNAME }}
+         password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: "Build and push docker image to DockerHub"
+       id: docker_build
+       uses: docker/build-push-action@v2
+       with:
+         push: ${{ (github.event_name == 'release' && github.event.action == 'created') || github.event.pull_request.head.repo.full_name == github.repository }}
+         tags: ${{ steps.prepare.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ jobs:
       - name: "Checkout source code at current commit"
         uses: actions/checkout@v2
       - name: Prepare tags for Docker image
-        if: github.event.release.action == 'created' || github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event.release.action == 'published' || github.event.pull_request.head.repo.full_name == github.repository
         id: prepare
         run: |
           TAGS=${{ github.repository }}:sha-${GITHUB_SHA:0:7}
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
-        if: github.event.release.action == 'created' || github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event.release.action == 'published' || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -40,5 +40,5 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v2
         with:
-          push: ${{ github.event.release.action == 'created' || github.event.pull_request.head.repo.full_name == github.repository }}
+          push: ${{ github.event.release.action == 'published' || github.event.pull_request.head.repo.full_name == github.repository }}
           tags: ${{ steps.prepare.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ jobs:
       - name: "Checkout source code at current commit"
         uses: actions/checkout@v2
       - name: Prepare tags for Docker image
-        if: (github.event_name != 'pull_request' && github.ref =~ 'ref/tags/.*') || github.event.pull_request.head.repo.full_name == github.repository
+        if: (github.event_name != 'pull_request' && startsWith(github.ref, 'ref/tags/')) || github.event.pull_request.head.repo.full_name == github.repository
         id: prepare
         run: |
           TAGS=${{ github.repository }}:sha-${GITHUB_SHA:0:7}
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
-        if: (github.event_name != 'pull_request' && github.ref =~ 'ref/tags/.*') || github.event.pull_request.head.repo.full_name == github.repository
+        if: (github.event_name != 'pull_request' && startsWith(github.ref, 'ref/tags/') || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -40,5 +40,5 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v2
         with:
-          push: ${{ (github.event_name != 'pull_request' && github.ref =~ 'ref/tags/.*') || github.event.pull_request.head.repo.full_name == github.repository }}
+          push: ${{ (github.event_name != 'pull_request' && startsWith(github.ref, 'ref/tags/') || github.event.pull_request.head.repo.full_name == github.repository }}
           tags: ${{ steps.prepare.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
-        if: (github.event_name != 'pull_request' && startsWith(github.ref, 'ref/tags/') || github.event.pull_request.head.repo.full_name == github.repository
+        if: (github.event_name != 'pull_request' && startsWith(github.ref, 'ref/tags/')) || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -40,5 +40,5 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v2
         with:
-          push: ${{ (github.event_name != 'pull_request' && startsWith(github.ref, 'ref/tags/') || github.event.pull_request.head.repo.full_name == github.repository }}
+          push: ${{ (github.event_name != 'pull_request' && startsWith(github.ref, 'ref/tags/')) || github.event.pull_request.head.repo.full_name == github.repository }}
           tags: ${{ steps.prepare.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ jobs:
       - name: "Checkout source code at current commit"
         uses: actions/checkout@v2
       - name: Prepare tags for Docker image
-        if: (github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/')) || github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event.release.action == 'created' || github.event.pull_request.head.repo.full_name == github.repository
         id: prepare
         run: |
           TAGS=${{ github.repository }}:sha-${GITHUB_SHA:0:7}
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
-        if: (github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/')) || github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event.release.action == 'created' || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -40,5 +40,5 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v2
         with:
-          push: ${{ (github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/')) || github.event.pull_request.head.repo.full_name == github.repository }}
+          push: ${{ github.event.release.action == 'created' || github.event.pull_request.head.repo.full_name == github.repository }}
           tags: ${{ steps.prepare.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,13 +1,10 @@
 name: "docker"
 on:
   push:
-    branches:
-      - master
+    tags:
+      - '*.*.*'
   pull_request: 
     types: [opened, synchronize, reopened]
-  release:
-    types:
-      - created
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
@@ -15,7 +12,7 @@ jobs:
       - name: "Checkout source code at current commit"
         uses: actions/checkout@v2
       - name: Prepare tags for Docker image
-        if: (github.event_name != 'pull_request' && github.ref == 'master') || github.event.pull_request.head.repo.full_name == github.repository
+        if: (github.event_name != 'pull_request' && github.ref == 'ref/tags/*') || github.event.pull_request.head.repo.full_name == github.repository
         id: prepare
         run: |
           TAGS=${{ github.repository }}:sha-${GITHUB_SHA:0:7}
@@ -34,7 +31,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
-        if: (github.event_name != 'pull_request' && github.ref == 'master') || github.event.pull_request.head.repo.full_name == github.repository
+        if: (github.event_name != 'pull_request' && github.ref == 'ref/tags/*') || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -43,5 +40,5 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v2
         with:
-          push: ${{ (github.event_name != 'pull_request' && github.ref == 'master') || github.event.pull_request.head.repo.full_name == github.repository }}
+          push: ${{ (github.event_name != 'pull_request' && github.ref == 'ref/tags/*') || github.event.pull_request.head.repo.full_name == github.repository }}
           tags: ${{ steps.prepare.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,16 +29,16 @@ jobs:
           fi
           echo ::set-output name=tags::${TAGS}
       - name: Set up Docker Buildx
-       uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
-       if: (github.event_name == 'release' && github.event.action == 'created') || github.event.pull_request.head.repo.full_name == github.repository
-       uses: docker/login-action@v1
-       with:
-         username: ${{ secrets.DOCKERHUB_USERNAME }}
-         password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        if: (github.event_name == 'release' && github.event.action == 'created') || github.event.pull_request.head.repo.full_name == github.repository
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: "Build and push docker image to DockerHub"
-       id: docker_build
-       uses: docker/build-push-action@v2
-       with:
-         push: ${{ (github.event_name == 'release' && github.event.action == 'created') || github.event.pull_request.head.repo.full_name == github.repository }}
-         tags: ${{ steps.prepare.outputs.tags }}
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: ${{ (github.event_name == 'release' && github.event.action == 'created') || github.event.pull_request.head.repo.full_name == github.repository }}
+          tags: ${{ steps.prepare.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ jobs:
       - name: "Checkout source code at current commit"
         uses: actions/checkout@v2
       - name: Prepare tags for Docker image
-        if: (github.event_name != 'pull_request' && github.ref == 'ref/tags/*') || github.event.pull_request.head.repo.full_name == github.repository
+        if: (github.event_name != 'pull_request' && github.ref =~ 'ref/tags/.*') || github.event.pull_request.head.repo.full_name == github.repository
         id: prepare
         run: |
           TAGS=${{ github.repository }}:sha-${GITHUB_SHA:0:7}
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
-        if: (github.event_name != 'pull_request' && github.ref == 'ref/tags/*') || github.event.pull_request.head.repo.full_name == github.repository
+        if: (github.event_name != 'pull_request' && github.ref =~ 'ref/tags/.*') || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -40,5 +40,5 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v2
         with:
-          push: ${{ (github.event_name != 'pull_request' && github.ref == 'ref/tags/*') || github.event.pull_request.head.repo.full_name == github.repository }}
+          push: ${{ (github.event_name != 'pull_request' && github.ref =~ 'ref/tags/.*') || github.event.pull_request.head.repo.full_name == github.repository }}
           tags: ${{ steps.prepare.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ jobs:
       - name: "Checkout source code at current commit"
         uses: actions/checkout@v2
       - name: Prepare tags for Docker image
-        if: github.event.release.action == 'published' || github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event.release.action == 'released' || github.event.pull_request.head.repo.full_name == github.repository
         id: prepare
         run: |
           TAGS=${{ github.repository }}:sha-${GITHUB_SHA:0:7}
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
-        if: github.event.release.action == 'published' || github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event.release.action == 'released' || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -40,5 +40,5 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v2
         with:
-          push: ${{ github.event.release.action == 'published' || github.event.pull_request.head.repo.full_name == github.repository }}
+          push: ${{ github.event.release.action == 'released' || github.event.pull_request.head.repo.full_name == github.repository }}
           tags: ${{ steps.prepare.outputs.tags }}


### PR DESCRIPTION
## what?!

I had originally modeled the Github action build triggers against another project, and upon further analysis, I don't think the project I modeled is actually working properly. In a nutshell, the release `created` trigger wasn't firing when the `auto-release` workflow was executed, which means we were never getting Docker images with actual semver tags in Docker Hub.

In addition, I had to cleanup some of the expression logic to properly match `github.ref`.

Anyhow, I was able to test it in my branch before merging to master by just pushing a new tag, and I'm happy to report it's working. Here's the behavior...

- If you're pushing a new commit against a non-forked PR, it will build/push a new image to Docker hub (with both an `sha-<sha>` AND a `pr-<num>-merge` tag
- If a new tag (or release) is created, it will build an image and upload it to Docker hub using the proper semver format (generated by `auto-release`, but without the leading `v`)

What I haven't tested is the `auto-release` portion, but I'm fairly certain it should work with this method. Of course, I thought the past couple attempts would work, and I think I'm starting to question my own sanity at this point.