### PR TITLE
Update to pritunl 1.29.2664.67 and Ubuntu 18.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -12,10 +12,12 @@ EXPOSE 1194
 
 ENTRYPOINT ["/init"]
 
-ENV VERSION="1.29.2435.70"
+ENV VERSION="1.29.2664.67"
 
-RUN echo 'deb http://repo.pritunl.com/stable/apt xenial main' > /etc/apt/sources.list.d/pritunl.list \
-    && echo "deb http://build.openvpn.net/debian/openvpn/stable xenial main" > /etc/apt/sources.list.d/openvpn-aptrepo.list \
+RUN apt-get update && apt-get install -y gnupg2 wget \
+    && wget -O - https://swupdate.openvpn.net/repos/repo-public.gpg|apt-key add - \
+    && echo 'deb http://repo.pritunl.com/stable/apt bionic main' > /etc/apt/sources.list.d/pritunl.list \
+    && echo "deb http://build.openvpn.net/debian/openvpn/stable bionic main" > /etc/apt/sources.list.d/openvpn-aptrepo.list \
     && apt-key adv --keyserver hkp://keyserver.ubuntu.com --recv 42F3E95A2C4F08279C4960ADD68FA50FEA312927 \
     && apt-key adv --keyserver hkp://keyserver.ubuntu.com --recv 7568D9BB55FF9E5287D586017AE645C0CF8E292A \
     && apt-key adv --keyserver hkp://keyserver.ubuntu.com --recv 8E6DA8B4E158C569 \
@@ -26,7 +28,7 @@ RUN echo 'deb http://repo.pritunl.com/stable/apt xenial main' > /etc/apt/sources
     && ln -sf /usr/share/zoneinfo/UTC /etc/localtime \
     && apt-get upgrade -y -q \
     && apt-get dist-upgrade -y -q \
-    && apt-get -y install pritunl iptables \
+    && apt-get -y install pritunl="${VERSION}*" iptables netcat \
     && apt-get clean \
     && apt-get -y -q autoclean \
     && apt-get -y -q autoremove \


### PR DESCRIPTION
## what 
- Update pritunl 1.29.2435.70 -> 1.29.2664.67 
- Update Ubuntu 16.04 -> 18.04
- Ensure that specified pritunl version is actually the one installed

## why
- Multiple bug fixes
- Bug fixes
- Previously the version installed would be the latest one available when the Docker build ran, which could produce inconsistent and misleading results.

## references
https://github.com/pritunl/pritunl/releases